### PR TITLE
Feature/oidc key resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,19 +29,17 @@ repositories {
 
 dependencies {
     compileOnly(group: 'javax', name: 'javaee-api', version: project['javax.version'])
-    compile(group: 'org.jboss.resteasy', name: 'resteasy-client', version: project['org.jboss.resteasy.version'])
     compile(group: 'org.slf4j', name: 'slf4j-api', version: project['org.slf4j.version'])
     compileOnly(group: 'org.slf4j', name: 'slf4j-log4j12', version: project['org.slf4j.version'])
     compile(group: 'org.bitbucket.b_c', name: 'jose4j', version: project['org.bitbucket.b_c.version'])
     compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project['com.fasterxml.jackson.version'])
-    compile(group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version: project['com.fasterxml.jackson.version'])
     compile(group: 'dk.bankdata.api', name:'types', version: project['dk.bankdata.api.version'])
-    compile(group: 'org.json', name: 'json', version: project['org.json.version'])
-
+    
     testCompile(group: 'javax', name: 'javaee-api', version: project['javax.version'])
-    testCompile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project['com.fasterxml.jackson.version'])
     testCompile(group: 'junit', name: 'junit', version: project['junit.version'])
-    testCompile(group: "org.mockito", name: "mockito-core", version: project['org.mockito.version'])
+    testCompile(group: 'org.mockito', name: 'mockito-core', version: project['org.mockito.version'])
+    testCompile(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: project['com.github.tomakehurst.wiremock-jre8.version'])
+    testCompile(group: 'org.glassfish.jersey.core', name: 'jersey-common', version: project['org.glassfish.jersey.core.version'])
 }
 
 model {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 version=0.1.2-SNAPSHOT
 
 com.fasterxml.jackson.version=2.9.8
+com.github.tomakehurst.wiremock-jre8.version=2.21.0
+dk.bankdata.api.version=1.0.2
+javax.version=7.0
 junit.version=4.11
 org.bitbucket.b_c.version=0.6.5
-javax.version=7.0
-org.jboss.resteasy.version=3.1.4.Final
-org.slf4j.version=1.7.25
-dk.bankdata.api.version=1.0.2
+org.glassfish.jersey.core.version=2.28
 org.mockito.version=2.21.0
-org.json.version=20180813
+org.slf4j.version=1.7.25

--- a/src/main/java/dk/bankdata/api/jaxrs/jwt/JwtFilter.java
+++ b/src/main/java/dk/bankdata/api/jaxrs/jwt/JwtFilter.java
@@ -1,40 +1,30 @@
 package dk.bankdata.api.jaxrs.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import dk.bankdata.api.types.ProblemDetails;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Priorities;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jose4j.jwk.JsonWebKey;
-import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.ErrorCodes;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumer;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
-import org.jose4j.keys.resolvers.JwksVerificationKeyResolver;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,22 +75,27 @@ public class JwtFilter implements ContainerRequestFilter {
 
     public static final String JWT_ATTRIBUTE = "JWT";
     private static final Logger LOG = LoggerFactory.getLogger(JwtFilter.class);
-    private static final long CONNECTION_TIMEOUT = 10000;
-    private static final long READ_TIMEOUT = 10000;
 
-    @Context private ResourceInfo resourceInfo;
-    @Context private HttpServletRequest request;
+    @Context
+    private ResourceInfo resourceInfo;
 
-    private List<String> approvedAudiences;
-    private List<String> approvedIssuers;
-    private URI proxy;
+    @Context
+    private HttpServletRequest request;
 
-    private Map<String, JsonWebKey> jwks = new HashMap<>();
+    private final List<String> approvedAudiences;
+    private final List<String> approvedIssuers;
+    private final OidcKeyResolver keyResolver;
 
     public JwtFilter(@NotNull List<String> approvedAudiences, @NotNull List<String> approvedIssuers, URI proxy) {
         this.approvedAudiences = approvedAudiences;
         this.approvedIssuers = approvedIssuers;
-        this.proxy = proxy;
+        if (proxy == null) {
+            this.keyResolver = new OidcKeyResolver(approvedIssuers.toArray(new String[0]));
+        } else {
+            this.keyResolver = new OidcKeyResolver(
+                    new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxy.getHost(), proxy.getPort())),
+                    approvedIssuers.toArray(new String[0]));
+        }
     }
 
     @Override
@@ -129,8 +124,6 @@ public class JwtFilter implements ContainerRequestFilter {
         }
 
         try {
-            getAndCacheJwks(approvedIssuers);
-
             JwtConsumer jwtConsumer = new JwtConsumerBuilder()
                     .setRequireExpirationTime()
                     .setAllowedClockSkewInSeconds(30)
@@ -138,7 +131,7 @@ public class JwtFilter implements ContainerRequestFilter {
                     .setRequireSubject()
                     .setExpectedAudience(approvedAudiences.toArray(new String[0]))
                     .setExpectedIssuers(true, approvedIssuers.toArray(new String[0]))
-                    .setVerificationKeyResolver(new JwksVerificationKeyResolver(getJsonWebKeySet().getJsonWebKeys()))
+                    .setVerificationKeyResolver(keyResolver)
                     .build();
 
             String jwt = authorizationHeader.replace("Bearer ", "");
@@ -180,98 +173,8 @@ public class JwtFilter implements ContainerRequestFilter {
         }
     }
 
-    private void getAndCacheJwks(List<String> approvedIssuers) {
-        for (String issuer : approvedIssuers) {
-            try {
-                if (!jwks.containsKey(issuer)) {
-                    JSONObject jsonObject = getWellKnown(issuer);
-                    JsonWebKey jsonWebKey = JsonWebKey.Factory.newJwk(jsonObject.toMap());
-                    jwks.put(issuer, jsonWebKey);
-                }
-            } catch (Exception e) {
-                LOG.error(e.getMessage(), e);
-
-                ProblemDetails.Builder builder = new ProblemDetails.Builder()
-                        .title("Error while caching jwks")
-                        .detail(e.getMessage())
-                        .status(Response.Status.UNAUTHORIZED.getStatusCode());
-
-                throw new ValidationException(builder.build(), e);
-
-            }
-        }
-    }
-
-    private JSONObject getWellKnown(String issuer) {
-        String wellKnownUrl = issuer + "/.well-known/openid-configuration";
-        Response response = executeApiCall(wellKnownUrl);
-
-        return new JSONObject(response.readEntity(String.class));
-    }
-
-    private Response executeApiCall(String url) {
-        Response response = null;
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-
-        ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder()
-                .establishConnectionTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
-                .socketTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                .register(new JacksonJsonProvider(objectMapper));
-
-        if (proxy != null) clientBuilder.defaultProxy(proxy.getHost(), proxy.getPort(), proxy.getScheme());
-
-        Client client = clientBuilder.build();
-
-        try {
-            response = client
-                    .target(url)
-                    .request()
-                    .get();
-        } catch (Exception e) {
-            Throwable cause = e.getCause();
-            StringBuilder sb = new StringBuilder();
-            sb.append(e.getMessage());
-            sb.append(" / ");
-            sb.append(cause != null ? cause.getMessage() : "cause was null");
-
-            ProblemDetails.Builder builder = new ProblemDetails.Builder()
-                    .title("Error while parsing well-known")
-                    .detail(sb.toString())
-                    .status(response == null ? 500 : response.getStatus());
-
-            throw new ValidationException(builder.build(), e);
-        }
-
-        validateResponse(response);
-
-        return response;
-    }
-
-    private void validateResponse(Response response) {
-        if (!response.getStatusInfo().equals(Response.Status.OK)) {
-            ProblemDetails.Builder builder = new ProblemDetails.Builder()
-                    .type(response.getLocation())
-                    .title("Error while validating response from oauth server")
-                    .status(response.getStatus());
-
-            throw new ValidationException(builder.build(), null);
-        }
-    }
-
-    private JsonWebKeySet getJsonWebKeySet() {
-        JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
-
-        for (Map.Entry<String, JsonWebKey> entry : jwks.entrySet()) {
-            jsonWebKeySet.addJsonWebKey(entry.getValue());
-        }
-
-        return jsonWebKeySet;
-    }
-
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
+    @Target({ElementType.TYPE, ElementType.METHOD})
     public @interface PublicApi {
     }
 }

--- a/src/main/java/dk/bankdata/api/jaxrs/jwt/OidcKeyResolver.java
+++ b/src/main/java/dk/bankdata/api/jaxrs/jwt/OidcKeyResolver.java
@@ -1,0 +1,121 @@
+package dk.bankdata.api.jaxrs.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jose4j.jwk.HttpsJwks;
+import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jwk.VerificationJwkSelector;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwx.JsonWebStructure;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+import org.jose4j.lang.JoseException;
+import org.jose4j.lang.UnresolvableKeyException;
+
+/**
+ * Key resolver to resolve keys based on the OpenID Connect Discovery specification. The resolver
+ * will be loading the keys dynamically based on the <code>.well-known/openid-configuration</code>
+ * document.
+ *
+ * @see org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver
+ */
+public class OidcKeyResolver implements VerificationKeyResolver {
+
+    private static final ObjectReader OIDC_READER = new ObjectMapper().readerFor(Map.class);
+    private VerificationJwkSelector verificationJwkSelector = new VerificationJwkSelector();
+    private Map<String, HttpsJwks> jwks = new HashMap<>();
+    private String[] issuers;
+    private Proxy proxy;
+
+    public OidcKeyResolver(Proxy proxy, String... issuers) {
+        this.proxy = proxy;
+        this.issuers = issuers;
+    }
+
+    public OidcKeyResolver(String... issuers) {
+        this(null, issuers);
+    }
+
+    @Override
+    public Key resolveKey(JsonWebSignature jws, List<JsonWebStructure> nestingContext) throws UnresolvableKeyException {
+        JsonWebKey key;
+        try {
+            JwtClaims claims = JwtClaims.parse(jws.getUnverifiedPayload());
+
+            String issuer = claims.getIssuer();
+            if (Arrays.stream(issuers).noneMatch(i -> i.equals(issuer))) {
+                throw new UnresolvableKeyException("Issuer " + issuer + " was not whitelisted!");
+            }
+
+            HttpsJwks jwks = getJwks(issuer);
+            key = verificationJwkSelector.select(jws, jwks.getJsonWebKeys());
+
+        } catch (InvalidJwtException | MalformedClaimException | JoseException | IOException e) {
+            throw new UnresolvableKeyException("Unable to resolve key", e);
+        }
+
+        if (key == null) {
+            throw new UnresolvableKeyException("Unable to find matching key for JWS based on issuer OpenId Connect Discovery");
+        }
+
+        return key.getKey();
+    }
+
+    private HttpsJwks getJwks(String issuer) throws UnresolvableKeyException {
+        try {
+            HttpsJwks keySet = jwks.get(issuer);
+            if (keySet == null) {
+                Map<String, Object> openIdConfig = getWellKnown(issuer);
+                keySet = new HttpsJwks(openIdConfig.get("jwks_uri").toString());
+                jwks.put(issuer, keySet);
+            }
+            return keySet;
+
+        } catch (Exception e) {
+            throw new UnresolvableKeyException("Error finding jwks_uri", e);
+        }
+    }
+
+    private Map<String, Object> getWellKnown(String issuer) throws UnresolvableKeyException {
+        try {
+            URL wellKnownUrl = issuer.endsWith("/")
+                    ? new URL(issuer + ".well-known/openid-configuration")
+                    : new URL(issuer + "/.well-known/openid-configuration");
+
+            URLConnection connection;
+            if (proxy != null) {
+                connection = wellKnownUrl.openConnection(proxy);
+            } else {
+                connection = wellKnownUrl.openConnection();
+            }
+
+            HashMap<String, Object> openIdConfig;
+            try (InputStream is = connection.getInputStream()) {
+                openIdConfig = OIDC_READER.readValue(is);
+            }
+
+            return openIdConfig;
+
+        } catch (IOException e) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(e.getMessage());
+            sb.append(" / ");
+            Throwable cause = e.getCause();
+            sb.append(cause != null ? cause.getMessage() : "cause was null");
+            throw new UnresolvableKeyException(sb.toString(), e);
+        }
+    }
+
+}

--- a/src/test/java/dk/bankdata/api/jaxrs/jwt/OidcKeyResolverTest.java
+++ b/src/test/java/dk/bankdata/api/jaxrs/jwt/OidcKeyResolverTest.java
@@ -1,0 +1,115 @@
+package dk.bankdata.api.jaxrs.jwt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertNotNull;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.security.Key;
+import org.jose4j.jwk.JsonWebKeySet;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.RsaJwkGenerator;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.lang.JoseException;
+import org.jose4j.lang.UnresolvableKeyException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class OidcKeyResolverTest {
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    RsaJsonWebKey rsaJsonWebKey;
+
+    @Before
+    public void setup() throws Exception {
+        generateKey();
+        setupJwks();
+        setupOpenIdConfiguration();
+    }
+
+    @Test
+    public void testResolveKey() throws Exception {
+        URI issuer = URI.create("http://localhost:" + wireMockRule.port() + "/oidc");
+        JwtClaims claims = createClaims(issuer);
+        JsonWebSignature jws = createJws(rsaJsonWebKey, claims);
+
+        OidcKeyResolver resolver = new OidcKeyResolver(issuer.toString());
+        Key key = resolver.resolveKey(jws, null);
+        assertNotNull(key);
+    }
+
+    @Test(expected = UnresolvableKeyException.class)
+    public void testInvalidIssuer() throws Exception {
+        URI issuer = URI.create("http://localhost:" + wireMockRule.port() + "/oidc");
+        JwtClaims claims = createClaims(issuer);
+        JsonWebSignature jws = createJws(rsaJsonWebKey, claims);
+
+        OidcKeyResolver resolver = new OidcKeyResolver("https://other-issuer");
+        resolver.resolveKey(jws, null);
+    }
+
+    @Test(expected = UnresolvableKeyException.class)
+    public void testInvalidKey() throws Exception {
+        URI issuer = URI.create("http://localhost:" + wireMockRule.port() + "/oidc");
+        JwtClaims claims = createClaims(issuer);
+        rsaJsonWebKey.setKeyId("unknown");
+        JsonWebSignature jws = createJws(rsaJsonWebKey, claims);
+
+        OidcKeyResolver resolver = new OidcKeyResolver("https://other-issuer");
+        resolver.resolveKey(jws, null);
+    }
+
+    private void generateKey() throws JoseException {
+        rsaJsonWebKey = RsaJwkGenerator.generateJwk(2048);
+        rsaJsonWebKey.setKeyId("k1");
+    }
+
+    private void setupOpenIdConfiguration() {
+        String openidConfiguration = "{\"jwks_uri\": \"http://localhost:" + wireMockRule.port() + "/jwks\"}";
+        stubFor(get(urlEqualTo("/oidc/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(openidConfiguration)));
+    }
+
+    private void setupJwks() {
+        JsonWebKeySet jwks = new JsonWebKeySet(rsaJsonWebKey);
+        stubFor(get(urlEqualTo("/jwks"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/jwk-set+json")
+                        .withBody(jwks.toJson())));
+    }
+
+    private JwtClaims createClaims(URI issuer) {
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(issuer.toString());
+        claims.setAudience("Audience");
+        claims.setExpirationTimeMinutesInTheFuture(10);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAtToNow();
+        claims.setNotBeforeMinutesInThePast(2);
+        claims.setSubject("subject");
+        return claims;
+    }
+
+    private JsonWebSignature createJws(RsaJsonWebKey rsaJsonWebKey, JwtClaims claims) throws JoseException {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(rsaJsonWebKey.getPrivateKey());
+        jws.setKeyIdHeaderValue(rsaJsonWebKey.getKeyId());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        jws.sign();
+        return jws;
+    }
+
+}


### PR DESCRIPTION
Moving JWKS lookup into jose4j key resolver to keep filter implementation more clean. Only depending on standard Java SE `URL` class to lookup the OpenID Connect Discovery document to avoid extra runtime library dependencies.