### PR TITLE
Ignore token on OPTIONS requests.

### DIFF
--- a/src/main/java/dk/bankdata/api/jaxrs/jwt/JwtFilter.java
+++ b/src/main/java/dk/bankdata/api/jaxrs/jwt/JwtFilter.java
@@ -19,6 +19,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -112,6 +113,10 @@ public class JwtFilter implements ContainerRequestFilter {
         if (resourceMethod.isAnnotationPresent(PublicApi.class)
             || resourceClass.isAnnotationPresent(PermitAll.class)
             || resourceMethod.isAnnotationPresent(PermitAll.class)) {
+            return;
+        }
+
+        if (HttpMethod.OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
             return;
         }
 

--- a/src/test/java/dk/bankdata/api/jaxrs/jwt/JwtFilterTest.java
+++ b/src/test/java/dk/bankdata/api/jaxrs/jwt/JwtFilterTest.java
@@ -4,10 +4,12 @@ import static dk.bankdata.api.jaxrs.jwt.JwtFilter.PublicApi;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import javax.annotation.security.PermitAll;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Response;
@@ -51,6 +53,18 @@ public class JwtFilterTest {
         when(resourceInfo.getResourceClass()).thenReturn((Class) AnnotationTestMethods.class);
 
         jwtFilter.filter(null);
+    }
+
+    @Test
+    public void shouldAllowOptionsRequest() throws Exception {
+        when(resourceInfo.getResourceClass()).thenReturn((Class) TestMethods.class);
+        when(resourceInfo.getResourceMethod()).thenReturn(TestMethods.class.getDeclaredMethod("methodWithoutAnnotation"));
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getMethod()).thenReturn(HttpMethod.OPTIONS);
+        jwtFilter.filter(requestContext);
+        verify(requestContext).getMethod();
+        verifyNoMoreInteractions(requestContext);
     }
 
     @Test


### PR DESCRIPTION
It should be ok to handle OPTIONS requests without bearer tokens.