### PR TITLE
Added Correlation ID filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,40 @@ public class Api {
     }
 }
 ```
+
+##### Correlation ID propagation
+
+This will add the `x-correlation-id` header value into MDC as `correlationId` and also propogate it into HTTP client calls.
+
+As this is a @Provider it has to be added to your application 
+
+```
+public class RestApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> providers = new HashSet<>(super.getClasses());
+        
+        providers.add(CorrelationIdFilter.class);
+
+        return providers;
+    }
+}
+```
+
+To output the Correlation ID into your logs, you need to setup your logging configuration to output the `correlationId` field, e.g. for logback console output:
+```
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %X{correlationId} [%thread] %-5level %logger{36} aaa - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+```

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testCompile(group: 'org.mockito', name: 'mockito-core', version: project['org.mockito.version'])
     testCompile(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: project['com.github.tomakehurst.wiremock-jre8.version'])
     testCompile(group: 'org.glassfish.jersey.core', name: 'jersey-common', version: project['org.glassfish.jersey.core.version'])
+    testCompile(group: 'org.slf4j', name: 'slf4j-log4j12', version: project['org.slf4j.version'])
 }
 
 model {

--- a/src/main/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilter.java
+++ b/src/main/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilter.java
@@ -1,23 +1,22 @@
 package dk.bankdata.api.jaxrs.logging;
 
-import org.slf4j.MDC;
-
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import org.slf4j.MDC;
 
 /**
- * Container and Client request filters that will propagate a Correlation ID to logs and downstream if it exists
+ * Container and Client request filters that will propagate a Correlation ID to logs and downstream if it exists.
  */
 public class CorrelationIdFilter implements ContainerRequestFilter, ContainerResponseFilter, ClientRequestFilter {
     static final String CORR_ID_HEADER_NAME = "x-correlation-id";
     static final String CORR_ID_FIELD_NAME = "correlationId";
 
     /**
-     * Injects the correlation ID into MDC, making it available to logging and HTTP clients
+     * Injects the correlation ID into MDC, making it available to logging and HTTP clients.
      */
     @Override
     public void filter(ContainerRequestContext requestContext) {
@@ -28,7 +27,7 @@ public class CorrelationIdFilter implements ContainerRequestFilter, ContainerRes
     }
 
     /**
-     * Injects the correlation ID into the HTTP client
+     * Injects the correlation ID into the HTTP client.
      */
     @Override
     public void filter(ClientRequestContext requestContext) {
@@ -39,9 +38,7 @@ public class CorrelationIdFilter implements ContainerRequestFilter, ContainerRes
     }
 
     /**
-     * Removes Correlation ID from MDC
-     *
-     * This is done to avoid re-use of the thread wrongly re-using the ID
+     * Removes Correlation ID from MDC to prevent same-thread mix of data.
      */
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {

--- a/src/main/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilter.java
+++ b/src/main/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilter.java
@@ -1,0 +1,50 @@
+package dk.bankdata.api.jaxrs.logging;
+
+import org.slf4j.MDC;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+/**
+ * Container and Client request filters that will propagate a Correlation ID to logs and downstream if it exists
+ */
+public class CorrelationIdFilter implements ContainerRequestFilter, ContainerResponseFilter, ClientRequestFilter {
+    static final String CORR_ID_HEADER_NAME = "x-correlation-id";
+    static final String CORR_ID_FIELD_NAME = "correlationId";
+
+    /**
+     * Injects the correlation ID into MDC, making it available to logging and HTTP clients
+     */
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String correlationId = requestContext.getHeaderString(CORR_ID_HEADER_NAME);
+        if (correlationId != null) {
+            MDC.put(CORR_ID_FIELD_NAME, correlationId);
+        }
+    }
+
+    /**
+     * Injects the correlation ID into the HTTP client
+     */
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        String correlationId = MDC.get(CORR_ID_FIELD_NAME);
+        if (correlationId != null) {
+            requestContext.getHeaders().putSingle(CORR_ID_HEADER_NAME, correlationId);
+        }
+    }
+
+    /**
+     * Removes Correlation ID from MDC
+     *
+     * This is done to avoid re-use of the thread wrongly re-using the ID
+     */
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        MDC.remove(CORR_ID_FIELD_NAME);
+    }
+}

--- a/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
+++ b/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
@@ -1,6 +1,7 @@
 package dk.bankdata.api.jaxrs.logging;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -14,14 +15,24 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_FIELD_NAME;
 import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_HEADER_NAME;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CorrelationIdFilterTest {
-    @InjectMocks CorrelationIdFilter correlationIdFilter;
+    @InjectMocks
+    CorrelationIdFilter correlationIdFilter;
+
+    @Before
+    public void init() {
+        //We must clear MDC to avoid issues if thread is re-used between two tests
+        MDC.clear();
+    }
 
     @Test
-    public void shouldPutCorrelationIdIntoMDC() {
+    public void shouldPutCorrelationIdIntoMdc() {
         //Arrange
         String corrId = "guid";
         ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
@@ -55,7 +66,7 @@ public class CorrelationIdFilterTest {
     }
 
     @Test
-    public void shouldNotPutToMDCWhenNoCorrelationId() {
+    public void shouldNotPutToMdcWhenNoCorrelationId() {
         //Arrange
         ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
 

--- a/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
+++ b/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
@@ -1,5 +1,16 @@
 package dk.bankdata.api.jaxrs.logging;
 
+import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_FIELD_NAME;
+import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_HEADER_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedMap;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -7,18 +18,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.MDC;
-
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.core.MultivaluedMap;
-
-import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_FIELD_NAME;
-import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_HEADER_NAME;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CorrelationIdFilterTest {

--- a/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
+++ b/src/test/java/dk/bankdata/api/jaxrs/logging/CorrelationIdFilterTest.java
@@ -1,0 +1,98 @@
+package dk.bankdata.api.jaxrs.logging;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.MDC;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_FIELD_NAME;
+import static dk.bankdata.api.jaxrs.logging.CorrelationIdFilter.CORR_ID_HEADER_NAME;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CorrelationIdFilterTest {
+    @InjectMocks CorrelationIdFilter correlationIdFilter;
+
+    @Test
+    public void shouldPutCorrelationIdIntoMDC() {
+        //Arrange
+        String corrId = "guid";
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+        when(containerRequestContext.getHeaderString(CORR_ID_HEADER_NAME)).thenReturn(corrId);
+
+        //Act
+        correlationIdFilter.filter(containerRequestContext);
+
+        //Assert
+        Assert.assertEquals(corrId, MDC.get("correlationId"));
+    }
+
+    @Test
+    public void shouldAddCorrelationIdToClientHeader() {
+        //Arrange
+        String corrId = "guid";
+
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+        when(containerRequestContext.getHeaderString(CORR_ID_HEADER_NAME)).thenReturn(corrId);
+        correlationIdFilter.filter(containerRequestContext);
+
+        MultivaluedMap<String, Object> headers = mock(MultivaluedMap.class);
+        ClientRequestContext request = mock(ClientRequestContext.class);
+        when(request.getHeaders()).thenReturn(headers);
+
+        //Act
+        correlationIdFilter.filter(request);
+
+        //Assert
+        verify(headers).putSingle(CORR_ID_HEADER_NAME, corrId);
+    }
+
+    @Test
+    public void shouldNotPutToMDCWhenNoCorrelationId() {
+        //Arrange
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+
+        //Act
+        correlationIdFilter.filter(containerRequestContext);
+
+        //Assert
+        Assert.assertNull(MDC.get(CORR_ID_FIELD_NAME));
+    }
+
+    @Test
+    public void shouldNotAddHeaderWhenNoCorrelationId() {
+        //Arrange
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+
+        //Act
+        ClientRequestContext request = mock(ClientRequestContext.class);
+
+        //Act
+        correlationIdFilter.filter(request);
+
+        //Assert
+        verifyZeroInteractions(request);
+    }
+
+    @Test
+    public void shouldRemoveCorrelationIdAfterResponseFilter() {
+        //Arrange
+        String corrId = "guid";
+        MDC.put(CORR_ID_FIELD_NAME, corrId);
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+        ContainerResponseContext containerResponseContext = mock(ContainerResponseContext.class);
+
+        //Act
+        correlationIdFilter.filter(containerRequestContext, containerResponseContext);
+
+        //Assert
+        Assert.assertNull(MDC.get("correlationId"));
+    }
+}


### PR DESCRIPTION
Added Correlation ID filter that, when enabled as a provider, automatically propagates the correlation ID to outgoing HTTP calls as well as puts it into MDC for access by logging frameworks.